### PR TITLE
when generate shipping_rates use only shipping_methods associated to store

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -2,6 +2,13 @@ Spree::ShippingMethod.class_eval do
   has_many :store_shipping_methods
   has_many :stores, :through => :store_shipping_methods
 
+  if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+    scope :available_to_store, ->(store) do
+      raise ArgumentError, "You must provide a store" if store.nil?
+      store.shipping_methods.empty? ? all : where(id: store.shipping_method_ids)
+    end
+  end
+
   # This adds store_match to the list of requirements.
   # This will need to be fixed for Spree 2.0 when split shipments is added
   def available_to_order?(order, display_on= nil)

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -1,0 +1,17 @@
+Spree::Stock::Estimator.class_eval do
+  if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+    def shipping_methods(package)
+      package.shipping_methods
+        .available_to_store(package.shipment.order.store)
+        .available_for_address(package.shipment.order.ship_address)
+        .includes(:calculator, tax_category: :tax_rates)
+        .to_a
+        .select do |ship_method|
+        calculator = ship_method.calculator
+        calculator.available?(package) &&
+          (calculator.preferences[:currency].blank? ||
+           calculator.preferences[:currency] == package.shipment.order.currency)
+      end
+    end
+  end
+end

--- a/spec/features/checkout_delivery_spec.rb
+++ b/spec/features/checkout_delivery_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe 'Checkout delivery', type: :feature, js: true do
+  let!(:zone) { create(:zone) }
+  let!(:country) { create(:country) }
+  let!(:store_0) { create(:store, url: 'foo.lvh.me') }
+  let!(:store_1) { create(:store, url: 'bar.lvh.me') }
+  let!(:product) { create(:product) }
+  let!(:shipping_method_0) { create(:shipping_method, name: 'Shipping Store 0') }
+  let!(:shipping_method_1) { create(:shipping_method, name: 'Shipping Store 1') }
+  let!(:user) { create(:user) }
+  let!(:order) { create(:order, store: store_1, user: user) }
+
+  before(:each) do
+    product.stores << store_1
+    shipping_method_0.stores << store_0
+    shipping_method_1.stores << store_1
+
+    visit_store store_1, "/products/#{product.slug}"
+    click_button 'Add To Cart'
+    Spree::Order.last.update_column(:email, 'test@example.com')
+    click_button 'Checkout'
+
+    country = Spree::Country.first
+    within('#billing') do
+      fill_in 'First Name', with: 'Han'
+      fill_in 'Last Name', with: 'Solo'
+      fill_in 'Street Address', with: 'YT-1300'
+      fill_in 'City', with: 'Mos Eisley'
+      select 'United States of America', from: 'Country'
+      select country.states.first, from: 'order_bill_address_attributes_state_id'
+      fill_in 'Zip', with: '12010'
+      fill_in 'Phone', with: '(555) 555-5555'
+    end
+    click_on 'Save and Continue'
+  end
+
+  it 'should show only shipping method from store' do
+    expect(page).to have_current_path('/checkout/delivery')
+    expect(page).not_to have_content('Shipping Store 0')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ Capybara.register_driver(:poltergeist) do |app|
 end
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10
+Capybara.configure do |config|
+  config.always_include_port = true
+end
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
@@ -43,6 +46,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::Api::TestingSupport::Helpers, type: :controller
+  config.include FeatureHelpers, type: :feature
 
   config.before :suite do
     DatabaseCleaner.clean_with :truncation

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,16 +1,16 @@
 module FeatureHelpers
-	def visit_store(store, path = '/')
-		app_host = URI.join("http://#{store.url}").to_s
-		using_app_host(app_host) do
-			visit path
-		end
-	end
+  def visit_store(store, path = '/')
+    app_host = URI.join("http://#{store.url}").to_s
+    using_app_host(app_host) do
+      visit path
+    end
+  end
 
-	def using_app_host(host)
-		original_host = Capybara.app_host
-		Capybara.app_host = host
-		yield
-	ensure
-		Capybara.app_host = original_host
-	end
+  def using_app_host(host)
+    original_host = Capybara.app_host
+    Capybara.app_host = host
+    yield
+  ensure
+    Capybara.app_host = original_host
+  end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,0 +1,16 @@
+module FeatureHelpers
+	def visit_store(store, path = '/')
+		app_host = URI.join("http://#{store.url}").to_s
+		using_app_host(app_host) do
+			visit path
+		end
+	end
+
+	def using_app_host(host)
+		original_host = Capybara.app_host
+		Capybara.app_host = host
+		yield
+	ensure
+		Capybara.app_host = original_host
+	end
+end


### PR DESCRIPTION
This fix is already in master, but is necessary for older versions.