### PR TITLE
Pass args.last to layout when assuming a proc in Dynamic Template Rendering

### DIFF
--- a/lib/spree_multi_domain/dynamic_template_renderer.rb
+++ b/lib/spree_multi_domain/dynamic_template_renderer.rb
@@ -6,7 +6,7 @@ module SpreeMultiDomain
           store_layout = if layout.is_a?(String)
                            layout.gsub("layouts/", "layouts/#{@view.current_store.code}/")
                          else
-                           layout.call.try(:gsub, "layouts/", "layouts/#{@view.current_store.code}/")
+                           layout.call(args.last).try(:gsub, "layouts/", "layouts/#{@view.current_store.code}/")
                          end
 
           begin


### PR DESCRIPTION
The default layout is a proc that passes it's arguments to other `action_view` methods.
A `nil` error occurs in one of these methods if no args are passed to the proc. It's expected to receive the formats, which in the original method signature, is the last argument.

Original method: [template_renderer.rb:75](https://github.com/rails/rails/blob/5-2-0/actionview/lib/action_view/renderer/template_renderer.rb#L75-L77)

Proc created here: [layouts.rb:392](https://github.com/rails/rails/blob/5-2-0/actionview/lib/action_view/layouts.rb#L392)
This is the proc we call in [dynamic_template_renderer.rb:9](https://github.com/solidusio/solidus_multi_domain/blob/master/lib/spree_multi_domain/dynamic_template_renderer.rb#L9), causing the `nil` error in `action_view`.

A proposed fix was also suggested in #65, but rather than ignoring API controllers entirely, we can continue to pass the formats as expected by `action_view`