### PR TITLE
Replace Poltergeist with Headless Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 sudo: false
 language: ruby
+addons:
+  chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 rvm:
   - 2.3.1
+before_install:
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.4 DB=postgres

--- a/solidus_multi_domain.gemspec
+++ b/solidus_multi_domain.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "capybara", "~> 2.18"
-  s.add_development_dependency "poltergeist"
+  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "ffaker"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,11 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 
 require 'rspec/rails'
 require 'ffaker'
-
 require 'database_cleaner'
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 require 'selenium/webdriver'
+require 'cancan/matchers'
 
 Capybara.register_driver(:selenium_chrome_headless) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
@@ -27,6 +27,7 @@ end
 
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.default_max_wait_time = 10
+FactoryBot.use_parent_strategy = false
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
@@ -37,12 +38,6 @@ require 'spree/testing_support/preferences'
 require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/setup'
 require 'spree/testing_support/capybara_ext'
-
-require 'cancan/matchers'
-
-Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
-
-FactoryBot.use_parent_strategy = false
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,21 @@ require 'ffaker'
 require 'database_cleaner'
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
-require 'capybara/poltergeist'
-Capybara.register_driver(:poltergeist) do |app|
-  Capybara::Poltergeist::Driver.new app, timeout: 90
+require 'selenium/webdriver'
+
+Capybara.register_driver(:selenium_chrome_headless) do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless start-maximized] }
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
 end
-Capybara.javascript_driver = :poltergeist
+
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.default_max_wait_time = 10
 
 # Requires factories defined in spree_core


### PR DESCRIPTION
This patch aims to replace PhantomJS/Poltergeist with Headless Chrome/Selenium.

It also superseeds #97 as the changes proposed on that PR do not work with this extension —it currently breaks the test suite at random.