### PR TITLE
Update build status icon in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This extension allows a single Solidus instance to have several customer facing
 stores, with a single shared backend administration system (i.e. multi-store,
 single-vendor).
 
-[![Build Status](https://travis-ci.org/solidusio/solidus_multi_domain.svg?branch=master)](https://travis-ci.org/solidusio/solidus_multi_domain)
+[![Build Status](https://travis-ci.org/solidusio-contrib/solidus_multi_domain.svg?branch=master)](https://travis-ci.org/solidusio-contrib/solidus_multi_domain)
 
 Current features:
 ------------------


### PR DESCRIPTION
The repository was moved from

https://github.com/solidusio/solidus_multi_domain

to

https://github.com/solidusio-contrib/solidus_multi_domain<Paste>

so also the TravisCI build status icon needs an update.