### PR TITLE
Use the latest dev-support gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,6 @@ group :test do
   gem 'rails-controller-testing'
 end
 
-gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
+gem 'solidus_dev_support'
 
 gemspec


### PR DESCRIPTION
Just changes the reference, still does not apply all new extensions standard.