### PR TITLE
Revert "Fix Dependabot looking for Gemfile-local"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,4 @@ gemspec
 
 # Use a local Gemfile to include development dependencies that might not be
 # relevant for the project or for other contributors, e.g.: `gem 'pry-debug'`.
-send :send :eval_gemfile,, 'Gemfile-local' if File.exist? 'Gemfile-local'
+send :eval_gemfile, 'Gemfile-local' if File.exist? 'Gemfile-local'


### PR DESCRIPTION
This reverts commit 2b220d745931db245fd5708f41ba90a8a38ef9b7.

Due to break the [build](https://circleci.com/gh/solidusio-contrib/solidus_multi_domain). Also dependabot can't parse Gemfile #145

cc @aldesantis 