### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/solidus_multi_domain/engine.rb
+++ b/lib/solidus_multi_domain/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusMultiDomain
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 


### PR DESCRIPTION
Fix deprecation warning about `SolidusSupport::EngineExtensions::Decorators`