### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Installation
 Add solidus_multi_domain to your Gemfile:
 
 ```ruby
-gem 'solidus_multi_domain'
+gem 'solidus_multi_domain', github: 'solidusio-contrib/solidus_multi_domain'
 ```
 
 Bundle your dependencies and run the installation generator:


### PR DESCRIPTION
Currently the project is not using rubygems, so if we follow the current instructions we are not able to install it from github and we get an old version of it.
The PR fixes the installation instructions in the README.