### PR TITLE
fix: ShipmentsControllerDecorator namespacing

### DIFF
--- a/app/decorators/controllers/solidus_multi_domain/spree/api/shipments_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_multi_domain/spree/api/shipments_controller_decorator.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-module SpreeMultiStore
-  module Api
-    module ShipmentsControllerDecorator
-      def self.prepended(base)
-        base.prepend SolidusMultiDomain::CreateLineItemSupport
-      end
+module SolidusMultiDomain
+  module Spree
+    module Api
+      module ShipmentsControllerDecorator
+        def self.prepended(base)
+          base.prepend SolidusMultiDomain::CreateLineItemSupport
+        end
 
-      def mine
-        super
-        @shipments = @shipments.where(spree_orders: { store_id: current_store.id }) if @shipments
-      end
+        def mine
+          super
+          @shipments = @shipments.where(spree_orders: { store_id: current_store.id }) if @shipments
+        end
 
-      ::Spree::Api::ShipmentsController.prepend(self) if SolidusMultiDomain::Engine.api_available?
+        ::Spree::Api::ShipmentsController.prepend(self) if SolidusMultiDomain::Engine.api_available?
+      end
     end
   end
 end


### PR DESCRIPTION
Overview:

On Rails 6.1 it is impossible to use this gem due to a small error in namespacing:

```
expected file /home/zernie/.rvm/gems/ruby-2.7.2/bundler/gems/solidus_multi_domain-1a059c5c6436/app/decorators/controllers/solidus_multi_domain/spree/api/shipments_controller_decorator.rb to define constant SolidusMultiDomain::Spree::Api::ShipmentsControllerDecorator, but didn't (Zeitwerk::NameError)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidusio-contrib/solidus_multi_domain/158)
<!-- Reviewable:end -->
