### PR TITLE
replace deprecated Spree.t method with I18n.t

### DIFF
--- a/app/views/spree/admin/products/_index_headers.html.erb
+++ b/app/views/spree/admin/products/_index_headers.html.erb
@@ -1,1 +1,1 @@
-<th><%= Spree.t(:stores) %></th>
+<th><%= I18n.t('spree.stores') %></th>

--- a/app/views/spree/admin/products/_index_search_fields.html.erb
+++ b/app/views/spree/admin/products/_index_search_fields.html.erb
@@ -1,4 +1,4 @@
 <p>
-  <label><%= Spree.t(:store) %></label><br />
+  <label><%= I18n.t('spree.store') %></label><br />
   <%= f.select :stores_id_eq, Spree::Store.all.collect {|s| [s.name, s.id ] }, {:include_blank => true} %></p>
 </p>

--- a/app/views/spree/admin/products/_stores.html.erb
+++ b/app/views/spree/admin/products/_stores.html.erb
@@ -1,6 +1,6 @@
 <div class="stores">
   <%= hidden_field_tag 'update_store_ids', true %>
-  <%= f.label :stores, Spree.t(:stores)%><br />
+  <%= f.label :stores, I18n.t('spree.stores')%><br />
   <% Spree::Store.all.each do |store| %>
     <%= check_box_tag "product[store_ids][]", store.id, @product.stores.include?(store), id: "product_store_id_#{store.id}" %>
     <%= label_tag "product_store_id_#{store.id}", store.name %>

--- a/app/views/spree/admin/stores/new.html.erb
+++ b/app/views/spree/admin/stores/new.html.erb
@@ -1,12 +1,12 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:new_store) %>
+  <%= I18n.t('spree.new_store') %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_store_list), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
+    <%= button_link_to I18n.t('spree.back_to_store_list'), spree.admin_stores_path, :icon => 'icon-arrow-left' %>
   </li>
 <% end %>
 

--- a/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_inside_taxonomy_form">
   <%= f.field_container :name do %>
-    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+    <%= f.label :name, I18n.t('spree.name') %> <span class="required">*</span><br />
     <%= error_message_on :taxonomy, :name, :class => 'fullwidth title'  %>
     <%= text_field :taxonomy, :name  %>
   <% end %>
 </div>
 
 <p>
-  <%= f.label :name, Spree.t(:store) %> <span class="required">*</span><br />
+  <%= f.label :name, I18n.t('spree.store') %> <span class="required">*</span><br />
   <%= collection_select :taxonomy, :store_id, Spree::Store.all, :id, :name  %>
 </p>


### PR DESCRIPTION
Solidus v3 removed the deprecated method in favor of `I18n.t`