### PR TITLE
Wrap deface overrides in a module

### DIFF
--- a/app/overrides/decorate_admin_configurations_index.rb
+++ b/app/overrides/decorate_admin_configurations_index.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/admin/shared/_configuration_menu",
-  name: "multi_domain_admin_configurations_menu",
-  insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
-  disabled: false,
-  partial: "spree/shared/multi_domain_sidebar_entry"
-)
+module DecorateAdminConfigurationsIndex
+  Deface::Override.new(
+    virtual_path: "spree/admin/shared/_configuration_menu",
+    name: "multi_domain_admin_configurations_menu",
+    insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
+    disabled: false,
+    partial: "spree/shared/multi_domain_sidebar_entry"
+  )
+end

--- a/app/overrides/decorate_admin_products_form.rb
+++ b/app/overrides/decorate_admin_products_form.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/admin/products/_form",
-  name: "multi_domain_admin_product_form_meta",
-  insert_bottom: "[data-hook='admin_product_form_meta']",
-  partial: "spree/admin/products/stores",
-  disabled: false
-)
+module DecorateAdminProductsForm
+  Deface::Override.new(
+    virtual_path: "spree/admin/products/_form",
+    name: "multi_domain_admin_product_form_meta",
+    insert_bottom: "[data-hook='admin_product_form_meta']",
+    partial: "spree/admin/products/stores",
+    disabled: false
+  )
+end

--- a/app/overrides/decorate_admin_products_index.rb
+++ b/app/overrides/decorate_admin_products_index.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/admin/products/index",
-  name: "multi_domain_admin_products_index_headers",
-  insert_before: "[data-hook='admin_products_index_header_actions']",
-  partial: "spree/admin/products/index_headers",
-  disabled: false
-)
+module DecorateAdminProductsIndex
+  Deface::Override.new(
+    virtual_path: "spree/admin/products/index",
+    name: "multi_domain_admin_products_index_headers",
+    insert_before: "[data-hook='admin_products_index_header_actions']",
+    partial: "spree/admin/products/index_headers",
+    disabled: false
+  )
 
-Deface::Override.new(
-  virtual_path: "spree/admin/products/index",
-  name: "multi_domain_admin_products_index_rows",
-  insert_before: "[data-hook='admin_products_index_row_actions']",
-  partial: "spree/admin/products/index_rows",
-  disabled: false
-)
+  Deface::Override.new(
+    virtual_path: "spree/admin/products/index",
+    name: "multi_domain_admin_products_index_rows",
+    insert_before: "[data-hook='admin_products_index_row_actions']",
+    partial: "spree/admin/products/index_rows",
+    disabled: false
+  )
 
-Deface::Override.new(
-  virtual_path: "spree/admin/products/index",
-  name: "multi_domain_admin_products_index_search",
-  insert_top: "[data-hook='admin_products_index_search']",
-  partial: "spree/admin/products/index_search_fields",
-  disabled: false
-)
+  Deface::Override.new(
+    virtual_path: "spree/admin/products/index",
+    name: "multi_domain_admin_products_index_search",
+    insert_top: "[data-hook='admin_products_index_search']",
+    partial: "spree/admin/products/index_search_fields",
+    disabled: false
+  )
+end


### PR DESCRIPTION
Zeitwerk expects a class or module correctly named in these files in newer versions of Solidus using Zeitwrek.
We can simply create the expected named modules to appease Zeitwerk.

This fixes the tests against newer versions.